### PR TITLE
Enable stricter type checks

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,8 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      # TODO(johnsonmh): change this to google/dart:latest once latest supports NNBD.
-      image: google/dart:2.12-dev
+      image: google/dart:latest
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.0]
+
+Added `copyWith`, `addCalendarDays`, and `calendarDaysTill` to `DateTimeBasics`.
+
 ## [0.6.0]
 
 Remove object basics (`isNull` and `isNotNull`).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,11 +1,10 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
-  strong-mode:
-    implicit-casts: true
-    implicit-dynamic: true
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,7 @@
 
 import 'package:basics/basics.dart';
 
-main() async {
+void main() async {
   const numbers = <int>[2, 4, 8];
 
   if (numbers.all((n) => n.isEven)) {
@@ -15,6 +15,6 @@ main() async {
 
   for (var _ in 5.range) {
     print('waiting 500 milliseconds...');
-    await Future.delayed(500.milliseconds);
+    await Future<void>.delayed(500.milliseconds);
   }
 }

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -54,4 +54,65 @@ extension DateTimeBasics on DateTime {
   /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
   /// the same contract.
   bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
+
+  /// Copies a [DateTime], overriding specified values.
+  ///
+  /// A UTC [DateTime] will remain in UTC; a local [DateTime] will remain local.
+  DateTime copyWith({
+    int? year,
+    int? month,
+    int? day,
+    int? hour,
+    int? minute,
+    int? second,
+    int? millisecond,
+    int? microsecond,
+  }) {
+    return (isUtc ? DateTime.utc : DateTime.new)(
+      year ?? this.year,
+      month ?? this.month,
+      day ?? this.day,
+      hour ?? this.hour,
+      minute ?? this.minute,
+      second ?? this.second,
+      millisecond ?? this.millisecond,
+      microsecond ?? this.microsecond,
+    );
+  }
+
+  /// Adds a specified number of days to this [DateTime].
+  ///
+  /// Unlike `DateTime.add(Duration(days: numberOfDays))`, this adds calendar
+  /// days and not 24-hour increments.  When possible, it therefore leaves the
+  /// time of day unchanged if a DST change would occur during the time
+  /// interval. (The returned time can still be different from the original if
+  /// it would be invalid for the returned date.)
+  DateTime addCalendarDays(int numberOfDays) =>
+      copyWith(day: day + numberOfDays);
+
+  /// Returns the number of calendar days till the specified date.
+  ///
+  /// Returns a negative value if the specified date is in the past.  Ignores
+  /// the time of day.
+  ///
+  /// Example:
+  /// ```
+  /// DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1); // 1
+  /// DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1); // 1
+  /// ```
+  ///
+  /// This function intentionally does not take a [DateTime] argument to:
+  /// * More clearly indicate that it does not take time of day into account.
+  /// * Avoid potential problems if one [DateTime] is in UTC and the other is
+  ///   not.
+  int calendarDaysTill(int year, int month, int day) {
+    // Discard the time of day, and perform all calculations in UTC so that
+    // Daylight Saving Time adjustments are not a factor.
+    //
+    // Note that this intentionally isn't the same as `toUtc()`; we instead
+    // want to treat this `DateTime` object *as* a UTC `DateTime`.
+    final startDay = DateTime.utc(this.year, this.month, this.day);
+    final endDay = DateTime.utc(year, month, day);
+    return (endDay - startDay).inDays;
+  }
 }

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -116,7 +116,7 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].maxBy((e) => e.length).value; // 'aaa'
   /// ```
-  E? maxBy(Comparable Function(E) sortKey) =>
+  E? maxBy(Comparable<dynamic> Function(E) sortKey) =>
       this.max((a, b) => sortKey(a).compareTo(sortKey(b)));
 
   /// Returns the element of [this] with the least value for [sortKey], or
@@ -126,7 +126,7 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].minBy((e) => e.length).value; // 'a'
   /// ```
-  E? minBy(Comparable Function(E) sortKey) =>
+  E? minBy(Comparable<dynamic> Function(E) sortKey) =>
       this.min((a, b) => sortKey(a).compareTo(sortKey(b)));
 
   /// Returns the sum of all the values in this iterable, as defined by

--- a/lib/list_basics.dart
+++ b/lib/list_basics.dart
@@ -92,7 +92,7 @@ extension ListBasics<E> on List<E> {
   /// var list = [-12, 3, 10];
   /// list.sortBy((e) => e.toString().length); // list is now [3, 10, -12].
   /// ```
-  void sortBy(Comparable Function(E) sortKey) {
+  void sortBy(Comparable<dynamic> Function(E) sortKey) {
     this.sort((a, b) => sortKey(a).compareTo(sortKey(b)));
   }
 
@@ -105,7 +105,7 @@ extension ListBasics<E> on List<E> {
   /// var sorted = list.sortedCopyBy((e) => e.toString().length);
   /// // list is still [-12, 3, 10]. sorted is [3, 10, -12].
   /// ```
-  List<E> sortedCopyBy(Comparable Function(E) sortKey) {
+  List<E> sortedCopyBy(Comparable<dynamic> Function(E) sortKey) {
     return List<E>.of(this)..sortBy(sortKey);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@
 
 name: basics
 description: A Dart library containing convenient extension methods on basic Dart objects.
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/google/dart-basics
 authors:
   - johnsonmh@google.com <johnsonmh@google.com>
   - garciaz@google.com <garciaz@google.com>
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 dev_dependencies:
-  test: ^1.16.0-nullsafety.5
+  test: ^1.16.0

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('returns true for an empty iterable', () {
-      final empty = [];
+      final empty = <Object>[];
       final result = empty.none((e) => e.toString() == 'foo');
       expect(result, isTrue);
     });
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('returns false for an empty iterable', () {
-      final empty = [];
+      final empty = <Object>[];
       final result = empty.one((e) => e.toString() == 'foo');
       expect(result, isFalse);
     });
@@ -94,8 +94,8 @@ void main() {
     });
 
     test('returns false for two empty iterables', () {
-      final empty1 = [];
-      final empty2 = [];
+      final empty1 = <Object>[];
+      final empty2 = <Object>[];
 
       expect(empty1.containsAny(empty2), isFalse);
       expect(empty2.containsAny(empty1), isFalse);
@@ -147,8 +147,8 @@ void main() {
     });
 
     test('returns true for two empty iterables', () {
-      final empty1 = [];
-      final empty2 = [];
+      final empty1 = <Object>[];
+      final empty2 = <Object>[];
 
       expect(empty1.containsAll(empty2), isTrue);
     });
@@ -388,7 +388,7 @@ void main() {
       expect(<double>[].sum(), 0);
       expect(<num>[].sum((n) => n * 2), 0);
       expect(<String>[].sum((s) => s.length), 0);
-      expect([].sum((n) => n * 2), 0);
+      expect(<int>[].sum((n) => n * 2), 0);
     });
 
     test('returns sum of custom addend', () {
@@ -415,7 +415,7 @@ void main() {
 
   group('getRandom', () {
     test('returns null for an empty iterable', () {
-      expect([].getRandom(), isNull);
+      expect(<int>[].getRandom(), isNull);
     });
 
     test('returns the only value of an iterable of length 1', () {

--- a/test/list_basics_test.dart
+++ b/test/list_basics_test.dart
@@ -59,7 +59,7 @@ void main() {
         'starts from the final element if start is greater than the length '
         'of the list', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 100, end: 1), []);
+      expect(list.slice(start: 100, end: 1), <int>[]);
       expect(list.slice(start: 100, end: 1, step: -1), [4, 3]);
     });
 
@@ -81,65 +81,65 @@ void main() {
         'ends with the first element if end is less than the negative length '
         'of the list', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 2, end: -100), []);
+      expect(list.slice(start: 2, end: -100), <int>[]);
       expect(list.slice(start: 2, end: -100, step: -1), [3, 2, 1]);
     });
 
     test('returns an empty list if start and end are equal', () {
       final list = [1, 2, 3, 4, 5];
-      expect(list.slice(start: 2, end: 2), []);
-      expect(list.slice(start: -2, end: -2), []);
+      expect(list.slice(start: 2, end: 2), <int>[]);
+      expect(list.slice(start: -2, end: -2), <int>[]);
     });
 
     test(
         'returns an empty list if start and end are not equal but correspond '
         'to the same element', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 1, end: -3), []);
-      expect(list.slice(start: 2, end: -2), []);
+      expect(list.slice(start: 1, end: -3), <int>[]);
+      expect(list.slice(start: 2, end: -2), <int>[]);
     });
 
     test(
         'returns an empty list if start (or its equivalent index) is greater '
         'than end (or its equivalent index) and step is positive', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 3, end: 1), []);
-      expect(list.slice(start: -1, end: 1), []);
-      expect(list.slice(start: 3, end: -3), []);
-      expect(list.slice(start: -1, end: -3), []);
-      expect(list.slice(start: 3, end: -100), []);
+      expect(list.slice(start: 3, end: 1), <int>[]);
+      expect(list.slice(start: -1, end: 1), <int>[]);
+      expect(list.slice(start: 3, end: -3), <int>[]);
+      expect(list.slice(start: -1, end: -3), <int>[]);
+      expect(list.slice(start: 3, end: -100), <int>[]);
     });
 
     test(
         'returns an empty list if start (or its equivalent index) is less than '
         'end (or its equivalent index) and step is negative', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 1, end: 3, step: -1), []);
-      expect(list.slice(start: -3, end: 3, step: -1), []);
-      expect(list.slice(start: 1, end: -1, step: -1), []);
-      expect(list.slice(start: -3, end: -1, step: -1), []);
-      expect(list.slice(start: 1, end: 100, step: -1), []);
+      expect(list.slice(start: 1, end: 3, step: -1), <int>[]);
+      expect(list.slice(start: -3, end: 3, step: -1), <int>[]);
+      expect(list.slice(start: 1, end: -1, step: -1), <int>[]);
+      expect(list.slice(start: -3, end: -1, step: -1), <int>[]);
+      expect(list.slice(start: 1, end: 100, step: -1), <int>[]);
     });
 
     test('behaves predictably when the bounds are increased in any direction',
         () {
       final list = [1, 2, 3, 4];
 
-      expect(list.slice(start: 0, end: 0), []);
+      expect(list.slice(start: 0, end: 0), <int>[]);
       expect(list.slice(start: 0, end: 1), [1]);
       expect(list.slice(start: 0, end: 2), [1, 2]);
       expect(list.slice(start: 0, end: 3), [1, 2, 3]);
       expect(list.slice(start: 0, end: 4), [1, 2, 3, 4]);
       expect(list.slice(start: 0, end: 5), [1, 2, 3, 4]);
 
-      expect(list.slice(start: 0, end: -5), []);
-      expect(list.slice(start: 0, end: -4), []);
+      expect(list.slice(start: 0, end: -5), <int>[]);
+      expect(list.slice(start: 0, end: -4), <int>[]);
       expect(list.slice(start: 0, end: -3), [1]);
       expect(list.slice(start: 0, end: -2), [1, 2]);
       expect(list.slice(start: 0, end: -1), [1, 2, 3]);
 
-      expect(list.slice(start: 5, end: 4), []);
-      expect(list.slice(start: 4, end: 4), []);
+      expect(list.slice(start: 5, end: 4), <int>[]);
+      expect(list.slice(start: 4, end: 4), <int>[]);
       expect(list.slice(start: 3, end: 4), [4]);
       expect(list.slice(start: 2, end: 4), [3, 4]);
       expect(list.slice(start: 1, end: 4), [2, 3, 4]);
@@ -150,18 +150,18 @@ void main() {
       expect(list.slice(start: -4, end: 4), [1, 2, 3, 4]);
       expect(list.slice(start: -5, end: 4), [1, 2, 3, 4]);
 
-      expect(list.slice(start: 3, end: 3, step: -1), []);
+      expect(list.slice(start: 3, end: 3, step: -1), <int>[]);
       expect(list.slice(start: 3, end: 2, step: -1), [4]);
       expect(list.slice(start: 3, end: 1, step: -1), [4, 3]);
       expect(list.slice(start: 3, end: 0, step: -1), [4, 3, 2]);
 
-      expect(list.slice(start: 3, end: -1, step: -1), []);
+      expect(list.slice(start: 3, end: -1, step: -1), <int>[]);
       expect(list.slice(start: 3, end: -2, step: -1), [4]);
       expect(list.slice(start: 3, end: -3, step: -1), [4, 3]);
       expect(list.slice(start: 3, end: -4, step: -1), [4, 3, 2]);
       expect(list.slice(start: 3, end: -5, step: -1), [4, 3, 2, 1]);
 
-      expect(list.slice(start: 0, end: 0, step: -1), []);
+      expect(list.slice(start: 0, end: 0, step: -1), <int>[]);
       expect(list.slice(start: 1, end: 0, step: -1), [2]);
       expect(list.slice(start: 2, end: 0, step: -1), [3, 2]);
       expect(list.slice(start: 3, end: 0, step: -1), [4, 3, 2]);
@@ -171,13 +171,13 @@ void main() {
       expect(list.slice(start: -1, end: 0, step: -1), [4, 3, 2]);
       expect(list.slice(start: -2, end: 0, step: -1), [3, 2]);
       expect(list.slice(start: -3, end: 0, step: -1), [2]);
-      expect(list.slice(start: -4, end: 0, step: -1), []);
+      expect(list.slice(start: -4, end: 0, step: -1), <int>[]);
 
       expect(list.slice(start: -1, end: -5, step: -1), [4, 3, 2, 1]);
       expect(list.slice(start: -2, end: -5, step: -1), [3, 2, 1]);
       expect(list.slice(start: -3, end: -5, step: -1), [2, 1]);
       expect(list.slice(start: -4, end: -5, step: -1), [1]);
-      expect(list.slice(start: -5, end: -5, step: -1), []);
+      expect(list.slice(start: -5, end: -5, step: -1), <int>[]);
     });
   });
 
@@ -214,7 +214,7 @@ void main() {
 
   group('takeRandom', () {
     test('returns null for an empty list', () {
-      expect([].takeRandom(), isNull);
+      expect(<Object>[].takeRandom(), isNull);
     });
 
     test('removes the only element of a list of length 1', () {

--- a/test/map_basics_test.dart
+++ b/test/map_basics_test.dart
@@ -60,8 +60,8 @@ void main() {
     });
 
     test('returns an empty map when called on an empty map', () {
-      final map = {};
-      expect(map.invert(), {});
+      final map = <Object, Object>{};
+      expect(map.invert(), <Object, Object>{});
     });
   });
 }


### PR DESCRIPTION
Enable the `strict-casts`, `strict-inference`, and `strict-raw-types`
options for the analyzer.  Fix missing types accordingly.